### PR TITLE
fix: don't fail when config entries are absent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.pupskuchen</groupId>
     <artifactId>timecontrol</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <packaging>jar</packaging>
     <name>TimeControl</name>
     <url>https://github.com/Pupskuchen/spigot-TimeControl</url>

--- a/src/main/java/net/pupskuchen/timecontrol/config/ConfigHandler.java
+++ b/src/main/java/net/pupskuchen/timecontrol/config/ConfigHandler.java
@@ -26,6 +26,8 @@ public class ConfigHandler {
     private final TimeControl plugin;
     private final PluginConfig pluginConfig;
 
+    private final TimeControlConfig fallbackConfig = getFallbacks();
+
     private boolean debug = false;
     private TimeControlConfig defaultConfig;
     private Map<String, WorldTimeControlConfig> worldConfigs = new HashMap<>();
@@ -41,7 +43,7 @@ public class ConfigHandler {
     }
 
     public void validate() {
-        defaultConfig = pluginConfig.get(DEFAULTS);
+        defaultConfig = pluginConfig.get(DEFAULTS, fallbackConfig);
 
         worldConfigs = loadWorlds(pluginConfig.get(WORLDS, defaultConfig));
     }
@@ -96,5 +98,10 @@ public class ConfigHandler {
 
         return worldConfigs.stream()
                 .collect(Collectors.toMap(WorldTimeControlConfig::getName, config -> config));
+    }
+
+    private TimeControlConfig getFallbacks() {
+        return new TimeControlConfig(new Durations<Double, Void>(10d, 500d / 60, null, null), true,
+                false, 100);
     }
 }

--- a/src/main/java/net/pupskuchen/timecontrol/config/entity/TimeControlConfig.java
+++ b/src/main/java/net/pupskuchen/timecontrol/config/entity/TimeControlConfig.java
@@ -17,6 +17,17 @@ public class TimeControlConfig {
     @Serialize("players-sleeping-percentage.percentage")
     protected Integer playersSleepingPercentage;
 
+    public TimeControlConfig() {}
+
+    public TimeControlConfig(final Durations<Double, ?> durations,
+            final boolean nightSkippingEnabled, final boolean playersSleepingPercentageEnabled,
+            final int playersSleepingPercentage) {
+        setDurations(durations);
+        this.nightSkippingEnabled = nightSkippingEnabled;
+        this.playersSleepingPercentageEnabled = playersSleepingPercentageEnabled;
+        this.playersSleepingPercentage = playersSleepingPercentage;
+    }
+
     public Durations<Double, ?> getDurations() {
         return durations;
     }


### PR DESCRIPTION
use hardcoded fallbacks instead